### PR TITLE
bugfix: parse url error once the PDF file passed with params in url

### DIFF
--- a/src/pdf-vue3.vue
+++ b/src/pdf-vue3.vue
@@ -106,7 +106,7 @@ const getDoc = () => {
   };
   if (props.src instanceof Uint8Array) {
     option.data = props.src;
-  } else if (props.src.endsWith(".pdf")) {
+  } else if (props.src.split('?')[0].endsWith(".pdf")) {
     option.url = props.src;
   } else {
     const binaryData = atob(


### PR DESCRIPTION
When the url brings params like:
**https://example.com/test.pdf?token=XXXX&timestamp=1**
The url **DOES NOT END UP WITH '.pdf'**, while this is apparently a pdf link, BOOM!
The error report appears to be:
pdf-vue3.js?v=15f95212:107 Uncaught (in promise) DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.